### PR TITLE
💅 disable arrow parens in prettier

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,6 @@
 module.exports = {
-  trailingComma: 'es5',
-  singleQuote: true,
+  arrowParens: 'avoid',
   printWidth: 100,
+  singleQuote: true,
+  trailingComma: 'es5'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-compono",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-compono",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Standard eslint config for Compono Projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Upgrading prettier to v2 has changed the default for arrow parens
https://prettier.io/docs/en/options.html#arrow-function-parentheses

Setting this back to what we had before.